### PR TITLE
Implement Notation Display Component and Copying Notation String

### DIFF
--- a/client/src/components/dashboard/NotationDisplay.js
+++ b/client/src/components/dashboard/NotationDisplay.js
@@ -1,0 +1,72 @@
+import React, { useState } from 'react';
+
+import makeStyles from '@material-ui/core/styles/makeStyles';
+import Box from '@material-ui/core/Box';
+import Button from '@material-ui/core/Button';
+import IconButton from '@material-ui/core/IconButton';
+import CloseIcon from '@material-ui/icons/Close';
+import Dialog from '@material-ui/core/Dialog';
+import DialogTitle from '@material-ui/core/DialogTitle';
+import DialogContent from '@material-ui/core/DialogContent';
+import Typography from '@material-ui/core/Typography';
+
+import PositionCard from './PositionCard';
+
+
+const useStyles = makeStyles(theme => ({
+    root: {
+        textAlign: 'center',
+        verticalAlign: 'middle',
+      },
+
+    closeButton: {
+        position: 'absolute',
+        right: theme.spacing(1),
+        top: theme.spacing(1),
+        color: theme.palette.grey[500],
+      },
+}));
+
+const NotationDisplay = (props) => {
+    const classes = useStyles();
+
+    const [open, setOpen] = useState(false);
+
+    const handleClickOpen = () => {
+        setOpen(true);
+    }
+
+    const handleClose = () => {
+        setOpen(false);
+    }
+
+    return (
+        <Box className={classes.root}>
+            <Button onClick={handleClickOpen}>TEST</Button>
+            <Dialog onClose={handleClose} open={open}>
+                <DialogTitle>
+                    TITLE
+                    <IconButton className={classes.closeButton} onClick={handleClose}>
+                        <CloseIcon />
+                    </IconButton>
+                </DialogTitle>
+                <DialogContent dividers>
+                    <Typography gutterBottom>
+                        Name of Opening
+                    </Typography>
+                    <Typography gutterBottom>
+                        Picture of Opening
+                    </Typography>
+                    <Typography gutterBottom>
+                        Notation Info Copy Paste
+                    </Typography>
+                    <Typography gutterBottom>
+                        Confirmation: Play/Cancel
+                    </Typography>
+                </DialogContent>
+            </Dialog>
+        </Box>
+    )
+}
+
+export default NotationDisplay;

--- a/client/src/components/dashboard/NotationDisplay.js
+++ b/client/src/components/dashboard/NotationDisplay.js
@@ -1,14 +1,16 @@
-import React from 'react';
+import React, { useState } from 'react';
 
 import makeStyles from '@material-ui/core/styles/makeStyles';
 import Box from '@material-ui/core/Box';
 import IconButton from '@material-ui/core/IconButton';
 import CloseIcon from '@material-ui/icons/Close';
+import FileCopyIcon from '@material-ui/icons/FileCopy';
 import Dialog from '@material-ui/core/Dialog';
 import DialogTitle from '@material-ui/core/DialogTitle';
 import DialogContent from '@material-ui/core/DialogContent';
-import Typography from '@material-ui/core/Typography';
-import { Button, TextField } from '@material-ui/core';
+import Button from '@material-ui/core/Button';
+import TextField from '@material-ui/core/TextField'; 
+import Tooltip from '@material-ui/core/Tooltip';
 
 const useStyles = makeStyles(theme => ({
     dialog: {
@@ -32,14 +34,38 @@ const useStyles = makeStyles(theme => ({
         margin: 0,
     },
     notationCopy: {
+        textAlign: 'right',
         marginTop: '1.5rem',
-        marginBottom: '1rem',
+        height: '70px',
+    },
+    copyButton: {
+        position: 'relative',
+        right: theme.spacing(0.5),
+        bottom: theme.spacing(6.5),
+    },
+    buttons: {
+        width: '6rem',
+        float: 'middle',
+        marginLeft: 15,
+        marginRight: 15,
     },
 }));
 
 const NotationDisplay = (props) => {
     const classes = useStyles();
     const { open, handleClose, name, imageLink } = props.data;
+    const notation = 'insert notation info here';
+
+    const [tooltipClicked, setTooltipClicked] = useState('Copy Text');
+
+    const closeTooltip = () => {
+        setTooltipClicked('Copy Text');
+    }
+
+    const clickTooltip = () => {
+        setTooltipClicked('Copied!')
+        navigator.clipboard.writeText(notation);
+    }
 
     return (
         <Box className={classes.root}>
@@ -52,22 +78,35 @@ const NotationDisplay = (props) => {
                     </IconButton>
                 </DialogTitle>
                 <DialogContent dividers>
-                    <Typography gutterBottom>
-                        <img className={classes.image} src={imageLink} alt={name} />
-                    </Typography>
-                    <Typography gutterBottom>
+                    <img className={classes.image} src={imageLink} alt={name} />
+                    <Box className={classes.notationCopy}>
                         <TextField 
-                            className={classes.notationCopy} 
-                            label="Notation Info"
-                            id="outlined-basic" 
-                            variant="outlined" 
-                            defaultValue="insert notation info here"
-                            fullWidth />
-                    </Typography>
-                    <Typography gutterBottom className={classes.buttons}>
-                        <Button>Play</Button>
-                        <Button onClick={handleClose}>Cancel</Button>
-                    </Typography>
+                            label='Notation Info'
+                            id='outlined-read-only-input'
+                            variant='outlined' 
+                            defaultValue={notation} 
+                            fullWidth 
+                            InputProps={{
+                                readOnly: true,
+                            }}
+                        />
+                        <Tooltip 
+                            className={classes.tooltip} 
+                            onClose={closeTooltip} 
+                            title={tooltipClicked} 
+                            placement='top' 
+                            arrow 
+                            interactive
+                        >
+                            <IconButton className={classes.copyButton} onClick={clickTooltip}>
+                                <FileCopyIcon />
+                            </IconButton>
+                        </Tooltip>
+                    </Box>
+                    <Box>
+                        <Button className={classes.buttons} variant='outlined'>Play</Button>
+                        <Button className={classes.buttons} variant='outlined' onClick={handleClose}>Cancel</Button>
+                    </Box>    
                 </DialogContent>
             </Dialog>
         </Box>

--- a/client/src/components/dashboard/NotationDisplay.js
+++ b/client/src/components/dashboard/NotationDisplay.js
@@ -29,6 +29,12 @@ const useStyles = makeStyles(theme => ({
     },
     name: {
         margin: 0,
+        [theme.breakpoints.down('sm')]: {
+            fontSize: '28px',
+        },
+    },
+    image: {
+        width: '80%',
     },
     notationCopy: {
         textAlign: 'right',

--- a/client/src/components/dashboard/NotationDisplay.js
+++ b/client/src/components/dashboard/NotationDisplay.js
@@ -1,67 +1,72 @@
-import React, { useState } from 'react';
+import React from 'react';
 
 import makeStyles from '@material-ui/core/styles/makeStyles';
 import Box from '@material-ui/core/Box';
-import Button from '@material-ui/core/Button';
 import IconButton from '@material-ui/core/IconButton';
 import CloseIcon from '@material-ui/icons/Close';
 import Dialog from '@material-ui/core/Dialog';
 import DialogTitle from '@material-ui/core/DialogTitle';
 import DialogContent from '@material-ui/core/DialogContent';
 import Typography from '@material-ui/core/Typography';
-
-import PositionCard from './PositionCard';
-
+import { Button, TextField } from '@material-ui/core';
 
 const useStyles = makeStyles(theme => ({
-    root: {
+    dialog: {
         textAlign: 'center',
         verticalAlign: 'middle',
-      },
+        maxWidth: '100%',
+    },
 
     closeButton: {
         position: 'absolute',
         right: theme.spacing(1),
         top: theme.spacing(1),
         color: theme.palette.grey[500],
-      },
+    },
+
+    title: {
+        textAlign: 'center',
+    },
+    
+    name: {
+        margin: 0,
+    },
+    notationCopy: {
+        marginTop: '1.5rem',
+        marginBottom: '1rem',
+    },
 }));
 
 const NotationDisplay = (props) => {
     const classes = useStyles();
-
-    const [open, setOpen] = useState(false);
-
-    const handleClickOpen = () => {
-        setOpen(true);
-    }
-
-    const handleClose = () => {
-        setOpen(false);
-    }
+    const { open, handleClose, name, imageLink } = props.data;
 
     return (
         <Box className={classes.root}>
-            <Button onClick={handleClickOpen}>TEST</Button>
-            <Dialog onClose={handleClose} open={open}>
-                <DialogTitle>
-                    TITLE
+            <Dialog className={classes.dialog} onClose={handleClose} open={open}>
+                <DialogTitle className={classes.title}>
+                    You Chose To Play: 
+                    <h1 className={classes.name}>{name}</h1>
                     <IconButton className={classes.closeButton} onClick={handleClose}>
                         <CloseIcon />
                     </IconButton>
                 </DialogTitle>
                 <DialogContent dividers>
                     <Typography gutterBottom>
-                        Name of Opening
+                        <img className={classes.image} src={imageLink} alt={name} />
                     </Typography>
                     <Typography gutterBottom>
-                        Picture of Opening
+                        <TextField 
+                            className={classes.notationCopy} 
+                            label="Notation Info"
+                            id="outlined-basic" 
+                            variant="outlined" 
+                            defaultValue="insert notation info here"
+                            fullWidth />
                     </Typography>
-                    <Typography gutterBottom>
-                        Notation Info Copy Paste
-                    </Typography>
-                    <Typography gutterBottom>
-                        Confirmation: Play/Cancel
+                    <Typography gutterBottom className={classes.buttons}>
+                        <Button>Play</Button>
+                        <Button onClick={handleClose}>Cancel</Button>
                     </Typography>
                 </DialogContent>
             </Dialog>

--- a/client/src/components/dashboard/NotationDisplay.js
+++ b/client/src/components/dashboard/NotationDisplay.js
@@ -18,18 +18,15 @@ const useStyles = makeStyles(theme => ({
         verticalAlign: 'middle',
         maxWidth: '100%',
     },
-
     closeButton: {
         position: 'absolute',
         right: theme.spacing(1),
         top: theme.spacing(1),
         color: theme.palette.grey[500],
     },
-
     title: {
         textAlign: 'center',
     },
-    
     name: {
         margin: 0,
     },
@@ -55,7 +52,6 @@ const NotationDisplay = (props) => {
     const classes = useStyles();
     const { open, handleClose, name, imageLink } = props.data;
     const notation = 'insert notation info here';
-
     const [tooltipClicked, setTooltipClicked] = useState('Copy Text');
 
     const closeTooltip = () => {

--- a/client/src/components/dashboard/PositionCard.js
+++ b/client/src/components/dashboard/PositionCard.js
@@ -4,6 +4,7 @@ import makeStyles from '@material-ui/core/styles/makeStyles';
 import Paper from '@material-ui/core/Paper';
 import Typography from '@material-ui/core/Typography';
 import NotationDisplay from './NotationDisplay';
+import Box from '@material-ui/core/Box';
 
 const useStyles = makeStyles(theme => ({
   root: {
@@ -45,10 +46,12 @@ const PositionCard = (props) => {
   return (
     <Paper className={classes.root}>
       <NotationDisplay data={{ open, handleClose, name, imageLink }} />
-      <img className={classes.image} src={imageLink} alt={name} onClick={handleClickOpen}/>
-      <Typography className={classes.title}>
-        {name}
-      </Typography>
+      <Box onClick={handleClickOpen}>
+        <img className={classes.image} src={imageLink} alt={name} />
+        <Typography className={classes.title}>
+          {name}
+        </Typography>
+      </Box>
     </Paper>
   );
 };

--- a/client/src/components/dashboard/PositionCard.js
+++ b/client/src/components/dashboard/PositionCard.js
@@ -4,7 +4,6 @@ import makeStyles from '@material-ui/core/styles/makeStyles';
 import Paper from '@material-ui/core/Paper';
 import Typography from '@material-ui/core/Typography';
 import NotationDisplay from './NotationDisplay';
-import { Button } from '@material-ui/core';
 
 const useStyles = makeStyles(theme => ({
   root: {

--- a/client/src/components/dashboard/PositionCard.js
+++ b/client/src/components/dashboard/PositionCard.js
@@ -1,8 +1,10 @@
-import React from 'react';
+import React, { useState } from 'react';
 
 import makeStyles from '@material-ui/core/styles/makeStyles';
 import Paper from '@material-ui/core/Paper';
 import Typography from '@material-ui/core/Typography';
+import NotationDisplay from './NotationDisplay';
+import { Button } from '@material-ui/core';
 
 const useStyles = makeStyles(theme => ({
   root: {
@@ -31,9 +33,20 @@ const PositionCard = (props) => {
   const classes = useStyles();
   const { position } = props;
   const { name, imageLink } = position;
+  const [open, setOpen] = useState(false);
+
+  const handleClickOpen = () => {
+      setOpen(true);
+  }
+
+  const handleClose = () => {
+      setOpen(false);
+  }
+
   return (
     <Paper className={classes.root}>
-      <img className={classes.image} src={imageLink} alt={name} />
+      <NotationDisplay data={{ open, handleClose, name, imageLink }} />
+      <img className={classes.image} src={imageLink} alt={name} onClick={handleClickOpen}/>
       <Typography className={classes.title}>
         {name}
       </Typography>

--- a/client/src/components/dashboard/PositionCardContainer.js
+++ b/client/src/components/dashboard/PositionCardContainer.js
@@ -6,6 +6,7 @@ import Paper from '@material-ui/core/Paper';
 
 import PositionCard from './PositionCard';
 import { getMockPositions } from '../../mock/positions';
+import NotationDisplay from './NotationDisplay';
 
 const useStyles = makeStyles(theme => ({
   root: {
@@ -38,6 +39,7 @@ const PositionCardContainer = () => {
   const positions = getMockPositions();
   return (
     <Box className={classes.root}>
+      <NotationDisplay />
       <Paper className={classes.paper}>
         {positions.map((position) => (
           <Box className={classes.cardWrapper} key={position.name}>

--- a/client/src/components/dashboard/PositionCardContainer.js
+++ b/client/src/components/dashboard/PositionCardContainer.js
@@ -6,7 +6,6 @@ import Paper from '@material-ui/core/Paper';
 
 import PositionCard from './PositionCard';
 import { getMockPositions } from '../../mock/positions';
-import NotationDisplay from './NotationDisplay';
 
 const useStyles = makeStyles(theme => ({
   root: {
@@ -39,7 +38,6 @@ const PositionCardContainer = () => {
   const positions = getMockPositions();
   return (
     <Box className={classes.root}>
-      <NotationDisplay />
       <Paper className={classes.paper}>
         {positions.map((position) => (
           <Box className={classes.cardWrapper} key={position.name}>


### PR DESCRIPTION
This PR solves #28 and implements the modal window display when clicking on a card on the dashboard. Also allows user to copy text in the text field to clipboard.

### Deployment Link
https://opening-trai-notation-d-gdmrnd.herokuapp.com/

### Future TODO:

- The click event to open the notation display activates when clicking on the image of the card specifically. May look further into how to click on the whole card rather than just the image.
- Add notation algorithm to text field
- Add buttons for certain playing styles (e.g. sandbox, against CPU, against friend) and link relevant pages
- Fix hover text on copy button tooltip (trying to reset the text when closed, but user can see the text change back before tooltip completely closes)