### PR TITLE
47 get position endpoint by string matching

### DIFF
--- a/server/constants/base-routes.js
+++ b/server/constants/base-routes.js
@@ -1,5 +1,6 @@
 const baseRoutes = {
   users: '/api/users',
+  positions: '/api/positions',
 };
 
 module.exports = baseRoutes;

--- a/server/index.js
+++ b/server/index.js
@@ -5,6 +5,7 @@ require('dotenv').config();
 
 const { initializeDatabaseConnection } = require('./database/connection');
 const usersRouter = require('./routes/users');
+const positionsRouter = require('./routes/positions');
 const logger = require('./util/logger');
 const baseRoutes = require('./constants/base-routes');
 
@@ -18,6 +19,7 @@ app.use(cors());
 
 // API Routers
 app.use(baseRoutes.users, usersRouter);
+app.use(baseRoutes.positions, positionsRouter);
 
 // Heroku Post-Build Path
 app.use(express.static(path.join(__dirname, '../client/build')));

--- a/server/routes/positions.js
+++ b/server/routes/positions.js
@@ -10,10 +10,11 @@ const Position = require('../models/Position');
       const regexSearchFilter = new RegExp(searchFilter);
       const regexPositionFilter = { $regex: regexSearchFilter, $options: 'i' };
       Position.find(
-        { $or : [
+        { $or : 
+          [
             { variant : regexPositionFilter }, 
             { "baseOpening.name": regexPositionFilter }
-            ] 
+          ] 
         }).limit(90).then( (query) => {
         // TODO: Perform actions for Redux
         return res.status(200).json({ message: 'Done' });

--- a/server/routes/positions.js
+++ b/server/routes/positions.js
@@ -1,68 +1,70 @@
 const mongoose = require('mongoose');
 const express = require('express');
 const logger = require('../util/logger');
+
 const router = express.Router();
 const Position = require('../models/Position');
 
-  router.get('/search', async (_req, res) => {
-    try {
-      const searchFilter = _req.query.filter.replace(/[^a-z\s-']/gi, '')
-      const regexSearchFilter = new RegExp(searchFilter);
-      const regexPositionFilter = { $regex: regexSearchFilter, $options: 'i' };
-      Position.find(
-        { $or : 
-          [
-            { variant : regexPositionFilter }, 
-            { "baseOpening.name": regexPositionFilter }
-          ] 
-        }).limit(90).then( (query) => {
-        // TODO: Perform actions for Redux
-        return res.status(200).json({ message: 'Done' });
-      });
-  
-    } catch (err) {
-      logger.error(err);
-      return res.status(500).json(err);
-    }
-  });
+router.get('/search', async (_req, res) => {
+  try {
+    const searchFilter = _req.query.filter.replace(/[^a-z\s-']/gi, '');
+    const regexSearchFilter = new RegExp(searchFilter);
+    const regexPositionFilter = { $regex: regexSearchFilter, $options: 'i' };
+    Position.find(
+      {
+        $or: [
+          { variant: regexPositionFilter },
+          { 'baseOpening.name': regexPositionFilter },
+        ],
+      },
+    ).limit(90).then((query) => {
+      // TODO: Perform actions for Redux
+      return res.status(200).json({ data: query });
+    });
+  } catch (err) {
+    logger.error(err);
+    return res.status(500).json(err);
+  }
+});
 
-  router.get('/common-positions', async (_req, res) => {
-    try {
-      Position.aggregate(
-        [ 
-          {
-            $match: {
-              'baseOpening.baseId': {
-                $exists: true,
-                $ne: null
-              }
-            }
+router.get('/common-positions', async (_req, res) => {
+  try {
+    Position.aggregate(
+      [
+        {
+          $match: {
+            'baseOpening.baseId': {
+              $exists: true,
+              $ne: null,
+            },
           },
-          { 
-            $group: {
-          _id: '$baseOpening.baseId',
-          count: { $sum: 1 },
-            }
+        },
+        {
+          $group: {
+            _id: '$baseOpening.baseId',
+            count: { $sum: 1 },
           },
-          {
-            $sort: {count: -1 }
-          },
-        ]).limit(9).then((query) => {
-        listOfIds = query.map((item) => mongoose.Types.ObjectId(item._id));
-        
-        Position.find({
-          _id: {
-            $in: listOfIds
-          }
-        }).then( (query) => {
-            // TODO: Perform actions for redux
-          return res.status(200).json({ message: 'Done' });
-        })
-      })
-    } catch (err) {
-        logger.error(err);
-        return res.status(500).json(err);
-    }
+        },
+        {
+          $sort: { count: -1 },
+        },
+      ],
+    ).limit(9).then((aggQuery) => {
+      const listOfIds = aggQuery.map((item) => mongoose.Types.ObjectId(item._id));
+
+      Position.find({
+        _id: {
+          $in: listOfIds,
+        },
+      }).then((findQuery) => {
+        // TODO: Perform actions for redux
+        res.status(200).json({ data: findQuery });
+      });
+    });
+  } catch (err) {
+    logger.error(err);
+    return res.status(500).json(err);
+  }
 });
 
 module.exports = router;

--- a/server/routes/positions.js
+++ b/server/routes/positions.js
@@ -1,0 +1,62 @@
+const mongoose = require('mongoose');
+const express = require('express');
+const logger = require('../util/logger');
+const router = express.Router();
+const Position = require('../models/Position');
+
+  router.get('/search', async (_req, res) => {
+    try {
+      const searchFilter = _req.query.filter.replace(/[^a-z\s-']/gi, '')
+      const regexSearchFilter = new RegExp(searchFilter);
+      const regexPositionFilter = { $regex: regexSearchFilter, $options: 'i' };
+      Position.find({ $or : [{ variant : regexPositionFilter}, { "baseOpening.name": regexPositionFilter }] }).limit(90).then( (query) => {
+        // TODO: Perform actions for Redux
+        return res.status(200).json({ message: 'Done' });
+      });
+  
+    } catch (err) {
+      logger.error(err);
+      return res.status(500).json(err);
+    }
+  });
+
+  router.get('/common-positions', async (_req, res) => {
+    try {
+      Position.aggregate(
+        [ 
+          {
+            $match: {
+              'baseOpening.baseId': {
+                $exists: true,
+                $ne: null
+              }
+            }
+          },
+          { 
+            $group: {
+          _id: '$baseOpening.baseId',
+          count: { $sum: 1 },
+            }
+          },
+          {
+            $sort: {count: -1 }
+          },
+        ]).limit(9).then((query) => {
+        listOfIds = query.map((item) => mongoose.Types.ObjectId(item._id));
+        
+        Position.find({
+          _id: {
+            $in: listOfIds
+          }
+        }).then( (query) => {
+            // TODO: Perform actions for redux
+          return res.status(200).json({ message: 'Done' });
+        })
+      })
+    } catch (err) {
+        logger.error(err);
+        return res.status(500).json(err);
+    }
+});
+
+module.exports = router;

--- a/server/routes/positions.js
+++ b/server/routes/positions.js
@@ -9,7 +9,12 @@ const Position = require('../models/Position');
       const searchFilter = _req.query.filter.replace(/[^a-z\s-']/gi, '')
       const regexSearchFilter = new RegExp(searchFilter);
       const regexPositionFilter = { $regex: regexSearchFilter, $options: 'i' };
-      Position.find({ $or : [{ variant : regexPositionFilter}, { "baseOpening.name": regexPositionFilter }] }).limit(90).then( (query) => {
+      Position.find(
+        { $or : [
+            { variant : regexPositionFilter }, 
+            { "baseOpening.name": regexPositionFilter }
+            ] 
+        }).limit(90).then( (query) => {
         // TODO: Perform actions for Redux
         return res.status(200).json({ message: 'Done' });
       });

--- a/server/tests/positions.spec.js
+++ b/server/tests/positions.spec.js
@@ -1,4 +1,3 @@
-/* eslint-disable mocha/no-setup-in-describe */
 const chai = require('chai');
 const chaiHttp = require('chai-http');
 const app = require('../index');
@@ -7,8 +6,10 @@ const baseRoutes = require('../constants/base-routes');
 chai.use(chaiHttp);
 chai.should();
 
+const positionsBaseRoute = baseRoutes.positions;
+
 describe('Positions', function () {
-  describe(`GET ${baseRoutes.positions}/search?filter=Polish+Opening`, function () {
+  describe(`GET ${positionsBaseRoute}/search?filter=Polish+Opening`, function () {
     it('should return an array of positions', function (done) {
       chai.request(app)
         .get(`${baseRoutes.positions}/search?filter=Polish`)
@@ -20,7 +21,7 @@ describe('Positions', function () {
     });
   });
 
-  describe(`GET ${baseRoutes.positions}/common-positions`, function () {
+  describe(`GET ${positionsBaseRoute}/common-positions`, function () {
     it('should return an array of positions', function (done) {
       chai.request(app)
         .get(`${baseRoutes.positions}/common-positions`)

--- a/server/tests/positions.spec.js
+++ b/server/tests/positions.spec.js
@@ -1,0 +1,34 @@
+/* eslint-disable mocha/no-setup-in-describe */
+const chai = require('chai');
+const chaiHttp = require('chai-http');
+const app = require('../index');
+const baseRoutes = require('../constants/base-routes');
+
+chai.use(chaiHttp);
+chai.should();
+
+describe('Positions', function () {
+  describe(`GET ${baseRoutes.positions}/search?filter=Polish+Opening`, function () {
+    it('should return an array of positions', function (done) {
+      chai.request(app)
+        .get(`${baseRoutes.positions}/search?filter=Polish`)
+        .end((_err, res) => {
+          res.should.have.status(200);
+          res.body.should.have.property('data').and.to.be.an('array');
+          done();
+        });
+    });
+  });
+
+  describe(`GET ${baseRoutes.positions}/common-positions`, function () {
+    it('should return an array of positions', function (done) {
+      chai.request(app)
+        .get(`${baseRoutes.positions}/common-positions`)
+        .end((_err, res) => {
+          res.should.have.status(200);
+          res.body.should.have.property('data').and.to.be.an('array').and.to.have.property('length', 9);
+          done();
+        });
+    });
+  });
+});


### PR DESCRIPTION
**Overview**
-
The changes in the PR include creating endpoints so that the client is able to get common positions during application load and also an endpoint to search for positions. This resolves issues #47 and #48 and unblocks #43 and #42. The most common positions are calculated by aggregating how many variant openings a base opening has and we take the top 9 of the results. 

e.g.
http://localhost:5000/api/positions/search?filter=english+opening
http://localhost:5000/api/positions/common-positions

**Future TODOs** 
- 
- Supplemental work will be needed to store data that was retrieved into Redux to update the state.