### PR TITLE
Add color theming

### DIFF
--- a/client/src/App.js
+++ b/client/src/App.js
@@ -2,6 +2,7 @@ import React from 'react';
 import store from './redux/store';
 import { Provider } from 'react-redux';
 
+import { ThemeProvider } from '@material-ui/core/styles';
 import makeStyles from '@material-ui/core/styles/makeStyles';
 import Box from '@material-ui/core/Box';
 
@@ -11,6 +12,7 @@ import { Route, Switch, BrowserRouter } from 'react-router-dom';
 import AboutPage from './pages/AboutPage';
 import NotationInfoPage from './pages/NotationInfoPage';
 import CustomNotationPage from './pages/CustomNotationPage';
+import theme from './util/theme';
 
 const useStyles = makeStyles({
   root: {
@@ -23,20 +25,22 @@ const App = () => {
 
   return (
     <Provider store={store}>
-      <Box className={classes.root}>
-        <BrowserRouter>
-          <Route path='/' render={(history) => (
-            <Navbar location={history.location.pathname}/>
-          )} />
+      <ThemeProvider theme={theme}>
+        <Box className={classes.root}>
+          <BrowserRouter>
+            <Route path='/' render={(history) => (
+              <Navbar location={history.location.pathname} />
+            )} />
 
-          <Switch>
-            <Route exact path="/" component={DashboardPage} />
-            <Route path="/about" component={AboutPage} />
-            <Route path="/info" component={NotationInfoPage} />
-            <Route path="/custom" component={CustomNotationPage} />
-          </Switch>
-        </BrowserRouter>
-      </Box>
+            <Switch>
+              <Route exact path="/" component={DashboardPage} />
+              <Route path="/about" component={AboutPage} />
+              <Route path="/info" component={NotationInfoPage} />
+              <Route path="/custom" component={CustomNotationPage} />
+            </Switch>
+          </BrowserRouter>
+        </Box>
+      </ThemeProvider>
     </Provider>
   );
 };

--- a/client/src/components/dashboard/NotationDisplay.js
+++ b/client/src/components/dashboard/NotationDisplay.js
@@ -19,11 +19,13 @@ const useStyles = makeStyles(theme => ({
     verticalAlign: 'middle',
     maxWidth: '100%',
   },
+  root: {
+    backgroundColor: theme.palette.background.default,
+  },
   closeButton: {
     position: 'absolute',
     right: theme.spacing(1),
     top: theme.spacing(1),
-    color: theme.palette.grey[500],
   },
   title: {
     textAlign: 'center',
@@ -72,46 +74,49 @@ const NotationDisplay = (props) => {
 
   return (
     <Dialog className={classes.dialog} onClose={handleClose} open={open}>
-      <DialogTitle className={classes.title}>
-        You Chose To Play
-        <Typography className={classes.name}>
-          {name}
-        </Typography>
-        <IconButton className={classes.closeButton} onClick={handleClose}>
-          <CloseIcon />
-        </IconButton>
-      </DialogTitle>
-      <DialogContent dividers>
-        <img className={classes.image} src={imageSrc} alt={name} />
-        <Box className={classes.notationCopy}>
-          <TextField
-            label='PGN Notation'
-            id='outlined-read-only-input'
-            variant='outlined'
-            defaultValue={notation}
-            fullWidth
-            InputProps={{
-              readOnly: true,
-            }}
-          />
-          <Tooltip
-            className={classes.tooltip}
-            onClose={closeTooltip}
-            title={tooltipClicked}
-            placement='top'
-            arrow
-            interactive
-          >
-            <IconButton className={classes.copyButton} onClick={clickTooltip}>
-              <FileCopyIcon />
-            </IconButton>
-          </Tooltip>
-        </Box>
-        <Box>
-          <Button className={classes.buttons} variant='outlined'>Play</Button>
-          <Button className={classes.buttons} variant='outlined' onClick={handleClose}>Cancel</Button>
-        </Box>
-      </DialogContent>
+      <Box className={classes.root}>
+        <DialogTitle className={classes.title}>
+          You Chose To Play
+          <Typography className={classes.name}>
+            {name}
+          </Typography>
+          <IconButton className={classes.closeButton} onClick={handleClose}>
+            <CloseIcon />
+          </IconButton>
+        </DialogTitle>
+        <DialogContent dividers>
+          <img className={classes.image} src={imageSrc} alt={name} />
+          <Box className={classes.notationCopy}>
+            <TextField
+              label='PGN Notation'
+              id='outlined-read-only-input'
+              variant='outlined'
+              defaultValue={notation}
+              fullWidth
+              color='primary'
+              InputProps={{
+                readOnly: true,
+              }}
+            />
+            <Tooltip
+              className={classes.tooltip}
+              onClose={closeTooltip}
+              title={tooltipClicked}
+              placement='top'
+              arrow
+              interactive
+            >
+              <IconButton className={classes.copyButton} onClick={clickTooltip}>
+                <FileCopyIcon />
+              </IconButton>
+            </Tooltip>
+          </Box>
+          <Box>
+            <Button className={classes.buttons} variant='outlined'>Play</Button>
+            <Button className={classes.buttons} variant='outlined' onClick={handleClose}>Cancel</Button>
+          </Box>
+        </DialogContent>
+      </Box>
     </Dialog>
   )
 }

--- a/client/src/components/dashboard/PositionCard.js
+++ b/client/src/components/dashboard/PositionCard.js
@@ -12,6 +12,7 @@ const useStyles = makeStyles(theme => ({
   root: {
     height: '100%',
     cursor: 'pointer',
+    backgroundColor: theme.palette.surface.default,
   },
   image: {
     width: '85%',

--- a/client/src/components/dashboard/PositionCardContainer.js
+++ b/client/src/components/dashboard/PositionCardContainer.js
@@ -11,13 +11,14 @@ const useStyles = makeStyles(theme => ({
     display: 'flex',
   },
   paper: {
-    backgroundColor: '#d3d3d3',
+    backgroundColor: theme.palette.background.default,
     margin: '0 auto',
     padding: '0 0.5rem',
     display: 'grid',
     gridTemplateColumns: '1fr 1fr 1fr',
     marginBottom: '2rem',
     width: '60%',
+    maxWidth: '1000px',
     [theme.breakpoints.between('sm', 'md')]: {
       width: '75%',
     },

--- a/client/src/components/dashboard/SearchBar.js
+++ b/client/src/components/dashboard/SearchBar.js
@@ -30,6 +30,7 @@ const useStyles = makeStyles(theme => ({
     marginTop: '0.25rem',
     backgroundColor: theme.palette.primary.main,
     borderRadius: '5px',
+    cursor: 'pointer',
   }
 }));
 
@@ -39,9 +40,9 @@ const SearchBar = () => {
 
   return (
     <Box className={classes.root}>
-      <TextField className={classes.searchBar} id='outlined-basic' variant='outlined'/>
+      <TextField className={classes.searchBar} id='outlined-basic' variant='outlined' />
       <IconButton className={classes.searchButton} aria-label='search for openings' size='medium'>
-          <SearchIcon />
+        <SearchIcon />
       </IconButton>
     </Box>
   );

--- a/client/src/components/dashboard/SearchBar.js
+++ b/client/src/components/dashboard/SearchBar.js
@@ -10,30 +10,26 @@ const useStyles = makeStyles(theme => ({
     verticalAlign: 'middle',
   },
   searchBar: {
-    backgroundColor: 'white',
-    margin: '0 0.5%',
+    backgroundColor: theme.palette.surface.default,
     marginBottom: '2rem',
-    width: '30%',
+    width: '55%',
     fontSize: '1.5rem',
     borderRadius: '5px',
-    [theme.breakpoints.down('md')]: {
-      width: '40%',
-      height: '2rem'
-    }
+    [theme.breakpoints.between('sm', 'md')]: {
+      width: '60%',
+    },
+    [theme.breakpoints.down('sm')]: {
+      width: '80%',
+    },
   },
   searchButton: {
     justifyContent: 'center',
     height: '3rem',
     width: '3rem',
+    marginLeft: '1rem',
     marginTop: '0.25rem',
-    backgroundColor: '#E0E0E0',
-    borderColor: '#E0E0E0',
+    backgroundColor: theme.palette.primary.main,
     borderRadius: '5px',
-    [theme.breakpoints.down('md')]: {
-      width: '2rem',
-      height: '2rem',
-      marginTop: '0rem'
-    }
   }
 }));
 

--- a/client/src/components/navigation/Navbar.js
+++ b/client/src/components/navigation/Navbar.js
@@ -6,7 +6,7 @@ import Tab from '@material-ui/core/Tab';
 import Tabs from '@material-ui/core/Tabs';
 import { Link } from 'react-router-dom';
 
-const useStyles = makeStyles({
+const useStyles = makeStyles(theme => ({
   root: {
     padding: '1rem',
     marginBottom: '2rem',
@@ -14,7 +14,7 @@ const useStyles = makeStyles({
   text: {
     textAlign: 'center',
   },
-});
+}));
 
 // TODO: Add functionality for page changes when react-router is implemented
 const Navbar = (props) => {

--- a/client/src/components/navigation/Navbar.js
+++ b/client/src/components/navigation/Navbar.js
@@ -8,7 +8,6 @@ import { Link } from 'react-router-dom';
 
 const useStyles = makeStyles({
   root: {
-    backgroundColor: 'white',
     padding: '1rem',
     marginBottom: '2rem',
   },
@@ -34,9 +33,9 @@ const Navbar = (props) => {
         variant='fullWidth'
       >
         <Tab value={routes[0]} label='Home' component={Link} to={routes[0]} />
-        <Tab value={routes[1]} label='About' component={Link} to={routes[1]}  />
+        <Tab value={routes[1]} label='About' component={Link} to={routes[1]} />
         <Tab value={routes[2]} label='Opening Info' component={Link} to={routes[2]} />
-        <Tab value={routes[3]} label='Custom Notations' component={Link} to={routes[3]}  />
+        <Tab value={routes[3]} label='Custom Notations' component={Link} to={routes[3]} />
       </Tabs>
     </Box>
   );

--- a/client/src/index.css
+++ b/client/src/index.css
@@ -1,6 +1,6 @@
 body {
   margin: 0;
-  background-color: #282c34;
+  background-color: #22272e;
   font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Oxygen',
     'Ubuntu', 'Cantarell', 'Fira Sans', 'Droid Sans', 'Helvetica Neue',
     sans-serif;

--- a/client/src/pages/AboutPage.js
+++ b/client/src/pages/AboutPage.js
@@ -4,17 +4,16 @@ import makeStyles from '@material-ui/core/styles/makeStyles';
 import Box from '@material-ui/core/Box';
 import Typography from '@material-ui/core/Typography';
 
-
-const useStyles = makeStyles({
+const useStyles = makeStyles(theme => ({
   root: {
     textAlign: 'center',
   },
   text: {
+    color: theme.palette.text.primary,
     textAlign: 'center',
-    color: 'white',
     margin: '1rem 0.5rem',
   },
-});
+}));
 
 const AboutPage = () => {
   const classes = useStyles();

--- a/client/src/pages/CustomNotationPage.js
+++ b/client/src/pages/CustomNotationPage.js
@@ -4,16 +4,16 @@ import makeStyles from '@material-ui/core/styles/makeStyles';
 import Box from '@material-ui/core/Box';
 import Typography from '@material-ui/core/Typography';
 
-const useStyles = makeStyles({
+const useStyles = makeStyles(theme => ({
   root: {
     textAlign: 'center',
   },
   text: {
+    color: theme.palette.text.primary,
     textAlign: 'center',
-    color: 'white',
     margin: '1rem 0.5rem',
   },
-});
+}));
 
 const CustomNotationPage = () => {
   const classes = useStyles();

--- a/client/src/pages/DashboardPage.js
+++ b/client/src/pages/DashboardPage.js
@@ -9,14 +9,15 @@ import PositionCardContainer from '../components/dashboard/PositionCardContainer
 import { useDispatch, useSelector } from 'react-redux';
 import { getCommonPositions } from '../redux/actions/positionActions';
 
-const useStyles = makeStyles({
+const useStyles = makeStyles(theme => ({
   root: {
     textAlign: 'center',
   },
   text: {
+    color: theme.palette.text.primary,
     textAlign: 'center',
   },
-});
+}));
 
 const DashboardPage = () => {
   const classes = useStyles();

--- a/client/src/pages/NotationInfoPage.js
+++ b/client/src/pages/NotationInfoPage.js
@@ -4,16 +4,16 @@ import makeStyles from '@material-ui/core/styles/makeStyles';
 import Box from '@material-ui/core/Box';
 import Typography from '@material-ui/core/Typography';
 
-const useStyles = makeStyles({
+const useStyles = makeStyles(theme => ({
   root: {
     textAlign: 'center',
   },
   text: {
+    color: theme.palette.text.primary,
     textAlign: 'center',
-    color: 'white',
     margin: '1rem 0.5rem',
   },
-});
+}));
 
 const NotationInfoPage = () => {
   const classes = useStyles();

--- a/client/src/util/theme.js
+++ b/client/src/util/theme.js
@@ -1,0 +1,21 @@
+import { createMuiTheme } from '@material-ui/core/styles';
+
+const theme = createMuiTheme({
+  palette: {
+    primary: {
+      main: '#bb86fc',
+    },
+    secondary: {
+      main: '#02dbc6',
+    },
+    background: {
+      default: '#22272e',
+    },
+    surface: {
+      default: '#373e47',
+    },
+    type: 'dark',
+  },
+});
+
+export default theme;

--- a/client/src/util/theme.js
+++ b/client/src/util/theme.js
@@ -14,6 +14,10 @@ const theme = createMuiTheme({
     surface: {
       default: '#373e47',
     },
+    text: {
+      primary: '#cdd9e5',
+      secondary: '#adbac7',
+    },
     type: 'dark',
   },
 });


### PR DESCRIPTION
### Overview
This PR resolves #50 and sets up MUI theming based on GitHub dark mode.

Moving forward, color styling should almost never be hardcoded. Rather, colors should be grabbed from the `theme` object.

### Other Stuff
- Spacing fixes
- Fixed the spacing and hover cursor on the search bar