### PR TITLE
Setup game page

### DIFF
--- a/client/src/App.js
+++ b/client/src/App.js
@@ -34,11 +34,11 @@ const App = () => {
               <Navbar location={history.location.pathname} />
             )} />
             <Switch>
+              <Route exact path="/about" component={AboutPage} />
+              <Route exact path="/game" component={GamePage} />
+              <Route exact path="/info" component={NotationInfoPage} />
+              <Route exact path="/custom" component={CustomNotationPage} />
               <Route exact path="/" component={DashboardPage} />
-              <Route path="/about" component={AboutPage} />
-              <Route path="/game" component={GamePage} />
-              <Route path="/info" component={NotationInfoPage} />
-              <Route path="/custom" component={CustomNotationPage} />
             </Switch>
             <Route path='/' render={(history) => (
               <Footer location={history.location.pathname} />

--- a/client/src/App.js
+++ b/client/src/App.js
@@ -33,7 +33,6 @@ const App = () => {
             <Route path='/' render={(history) => (
               <Navbar location={history.location.pathname} />
             )} />
-
             <Switch>
               <Route exact path="/" component={DashboardPage} />
               <Route path="/about" component={AboutPage} />
@@ -41,7 +40,9 @@ const App = () => {
               <Route path="/info" component={NotationInfoPage} />
               <Route path="/custom" component={CustomNotationPage} />
             </Switch>
-            <Footer/>
+            <Route path='/' render={(history) => (
+              <Footer location={history.location.pathname} />
+            )} />
           </BrowserRouter>
         </Box>
       </ThemeProvider>

--- a/client/src/components/dashboard/NotationDisplay.js
+++ b/client/src/components/dashboard/NotationDisplay.js
@@ -1,17 +1,20 @@
 import React, { useState } from 'react';
 
+import { Link } from 'react-router-dom';
+
 import makeStyles from '@material-ui/core/styles/makeStyles';
 import Box from '@material-ui/core/Box';
 import Typography from '@material-ui/core/Typography';
 import IconButton from '@material-ui/core/IconButton';
-import CloseIcon from '@material-ui/icons/Close';
-import FileCopyIcon from '@material-ui/icons/FileCopy';
 import Dialog from '@material-ui/core/Dialog';
 import DialogTitle from '@material-ui/core/DialogTitle';
 import DialogContent from '@material-ui/core/DialogContent';
 import Button from '@material-ui/core/Button';
 import TextField from '@material-ui/core/TextField';
 import Tooltip from '@material-ui/core/Tooltip';
+
+import CloseIcon from '@material-ui/icons/Close';
+import FileCopyIcon from '@material-ui/icons/FileCopy';
 
 const useStyles = makeStyles(theme => ({
   dialog: {
@@ -112,7 +115,7 @@ const NotationDisplay = (props) => {
             </Tooltip>
           </Box>
           <Box>
-            <Button className={classes.buttons} variant='outlined'>Play</Button>
+            <Button className={classes.buttons} component={Link} to='/game' variant='outlined'>Play</Button>
             <Button className={classes.buttons} variant='outlined' onClick={handleClose}>Cancel</Button>
           </Box>
         </DialogContent>

--- a/client/src/components/footer/Footer.js
+++ b/client/src/components/footer/Footer.js
@@ -1,35 +1,41 @@
 import React from "react";
+
 import { makeStyles } from "@material-ui/core/styles";
 import BottomNavigation from "@material-ui/core/BottomNavigation";
 import Typography from "@material-ui/core/Typography";
 import Box from '@material-ui/core/Box';
 import Link from '@material-ui/core/Link';
 
-const useStyles = makeStyles({
+const useStyles = makeStyles(theme => ({
   root: {
+    color: theme.palette.text.primary,
     height: "10%",
     width: "100%",
   },
-});
+  hidden: {
+    display: 'none',
+  }
+}));
 
-export default function Footer() {
+const Footer = (props) => {
   const classes = useStyles();
+  const { location } = props;
 
   return (
-    <BottomNavigation className={classes.root}>
+    <BottomNavigation className={location !== '/game' ? classes.root : classes.hidden}>
       <Box>
         <Typography align="center" variant="overline" display="block">
           © 2021 Chocolate Thunder
         </Typography>
-        <span>
-          <Typography variant="overline">Credits to </Typography>
-          <Typography align="center" variant="overline">
-            <Link href="https://chessopenings.com/eco/" rel="noreferrer">
-              chessopenings.com
-            </Link>
-          </Typography>
-        </span>
+        <Typography variant="overline">Credits to the </Typography>
+        <Typography align="center" variant="overline">
+          <Link href="https://chessopenings.com/eco/" rel="noreferrer">
+            Encyclopedia of Chess Openings (ECO)
+          </Link>
+        </Typography>
       </Box>
     </BottomNavigation>
   );
 }
+
+export default Footer;

--- a/client/src/components/game/GameBoardContainer.js
+++ b/client/src/components/game/GameBoardContainer.js
@@ -25,6 +25,7 @@ const useStyles = makeStyles(theme => ({
   },
 }));
 
+// TODO: Add chessboard component
 const GameBoardContainer = () => {
   const classes = useStyles();
   return (
@@ -34,7 +35,7 @@ const GameBoardContainer = () => {
         <Box className={classes.chessboardContainer}>
           Insert Chessboard Here
         </Box>
-        <GamePlayerInfo playerName='Shrek' />
+        <GamePlayerInfo playerName='Shrek' human />
       </Box>
     </Box>
   );

--- a/client/src/components/game/GameBoardContainer.js
+++ b/client/src/components/game/GameBoardContainer.js
@@ -1,0 +1,43 @@
+import React from 'react';
+
+import makeStyles from '@material-ui/core/styles/makeStyles';
+import Box from '@material-ui/core/Box';
+
+import GamePlayerInfo from './GamePlayerInfo';
+
+const useStyles = makeStyles(theme => ({
+  root: {
+    height: '90%',
+    backgroundColor: theme.palette.surface.default,
+    margin: '0 5%',
+    marginTop: '5vh',
+    flexGrow: 1,
+  },
+  gameGridContainer: {
+    height: '90%',
+    display: 'grid',
+    gridTemplateRows: '1fr 8fr 1fr',
+    margin: '0% 10%',
+    paddingTop: '3%',
+  },
+  chessboardContainer: {
+    color: theme.palette.text.primary,
+  },
+}));
+
+const GameBoardContainer = () => {
+  const classes = useStyles();
+  return (
+    <Box className={classes.root}>
+      <Box className={classes.gameGridContainer}>
+        <GamePlayerInfo playerName='Stockfish' />
+        <Box className={classes.chessboardContainer}>
+          Insert Chessboard Here
+        </Box>
+        <GamePlayerInfo playerName='Shrek' />
+      </Box>
+    </Box>
+  );
+};
+
+export default GameBoardContainer;

--- a/client/src/components/game/GamePlayerInfo.js
+++ b/client/src/components/game/GamePlayerInfo.js
@@ -3,42 +3,44 @@ import React from 'react';
 import makeStyles from '@material-ui/core/styles/makeStyles';
 import Box from '@material-ui/core/Box';
 import Typography from '@material-ui/core/Typography';
-import Paper from '@material-ui/core/Paper';
+
+import AndroidIcon from '@material-ui/icons/Android';
+import PersonIcon from '@material-ui/icons/Person';
 
 const useStyles = makeStyles(theme => ({
-    root: {
-      display: 'grid',
-      gridTemplateColumns: '1fr 9fr',
-    },
-    playerImage: {
-      height: '100%',
-      width: '100%',
-    },
-    playerName: {
-      color: theme.palette.text.primary,
-      marginLeft: '1rem',
-      fontWeight: 'bold',
-      fontSize: '32px',
-    }
-  }));
+  root: {
+    display: 'grid',
+    gridTemplateColumns: '1fr 9fr',
+  },
+  playerIcon: {
+    fontSize: '50px',
+    color: theme.palette.text.primary,
+  },
+  playerName: {
+    color: theme.palette.text.primary,
+    marginLeft: '1rem',
+    fontWeight: 'bold',
+    fontSize: '32px',
+  }
+}));
 
 const GamePlayerInfo = (props) => {
-    const classes = useStyles();
-    const { playerName } = props;
-    return (
-        <Box className={classes.root}>
-          <Box>
-            <Paper className={classes.playerImage}>
-              Image
-            </Paper>
-          </Box>
-          <Box>
-            <Typography className={classes.playerName} align='left'>
-              {playerName}
-            </Typography>
-          </Box>
-        </Box>
-    );
+  const classes = useStyles();
+  const { playerName, human } = props;
+  return (
+    <Box className={classes.root}>
+      <Box>
+        <Typography>
+          {human ? <PersonIcon className={classes.playerIcon} />  : <AndroidIcon className={classes.playerIcon} />}
+        </Typography>
+      </Box>
+      <Box>
+        <Typography className={classes.playerName} align='left'>
+          {playerName}
+        </Typography>
+      </Box>
+    </Box>
+  );
 };
 
 export default GamePlayerInfo;

--- a/client/src/components/game/GamePlayerInfo.js
+++ b/client/src/components/game/GamePlayerInfo.js
@@ -1,0 +1,44 @@
+import React from 'react';
+
+import makeStyles from '@material-ui/core/styles/makeStyles';
+import Box from '@material-ui/core/Box';
+import Typography from '@material-ui/core/Typography';
+import Paper from '@material-ui/core/Paper';
+
+const useStyles = makeStyles(theme => ({
+    root: {
+      display: 'grid',
+      gridTemplateColumns: '1fr 9fr',
+    },
+    playerImage: {
+      height: '100%',
+      width: '100%',
+    },
+    playerName: {
+      color: theme.palette.text.primary,
+      marginLeft: '1rem',
+      fontWeight: 'bold',
+      fontSize: '32px',
+    }
+  }));
+
+const GamePlayerInfo = (props) => {
+    const classes = useStyles();
+    const { playerName } = props;
+    return (
+        <Box className={classes.root}>
+          <Box>
+            <Paper className={classes.playerImage}>
+              Image
+            </Paper>
+          </Box>
+          <Box>
+            <Typography className={classes.playerName} align='left'>
+              {playerName}
+            </Typography>
+          </Box>
+        </Box>
+    );
+};
+
+export default GamePlayerInfo;

--- a/client/src/components/game/GameSidebar.js
+++ b/client/src/components/game/GameSidebar.js
@@ -1,0 +1,39 @@
+import React from 'react';
+
+import makeStyles from '@material-ui/core/styles/makeStyles';
+import Box from '@material-ui/core/Box';
+import Typography from '@material-ui/core/Typography';
+
+const useStyles = makeStyles(theme => ({
+  openingNameBox: {
+    backgroundColor: theme.palette.background.default,
+    margin: '1rem',
+    padding: '1rem 0rem',
+  },
+  baseOpeningText: {
+    color: theme.palette.text.primary,
+    fontSize: '32px',
+  },
+  variationText: {
+    color: theme.palette.primary.main,
+    fontSize: '20px',
+  },
+}));
+
+const GameSidebar = () => {
+  const classes = useStyles();
+  return (
+    <>
+      <Box className={classes.openingNameBox}>
+        <Typography className={classes.baseOpeningText}>
+          Sicilian Defense
+        </Typography>
+        <Typography className={classes.variationText}>
+          Dragon Variation
+        </Typography>
+      </Box>
+    </>
+  );
+};
+
+export default GameSidebar;

--- a/client/src/components/game/GameSidebar.js
+++ b/client/src/components/game/GameSidebar.js
@@ -20,6 +20,7 @@ const useStyles = makeStyles(theme => ({
   },
 }));
 
+// TODO: Link opening and variation display to real game data 
 const GameSidebar = () => {
   const classes = useStyles();
   return (

--- a/client/src/pages/GamePage.js
+++ b/client/src/pages/GamePage.js
@@ -2,18 +2,24 @@ import React from 'react';
 
 import makeStyles from '@material-ui/core/styles/makeStyles';
 import Box from '@material-ui/core/Box';
-import Typography from '@material-ui/core/Typography';
+
+import GameBoardContainer from '../components/game/GameBoardContainer';
+import GameSidebar from '../components/game/GameSidebar';
 
 const useStyles = makeStyles(theme => ({
   root: {
     textAlign: 'center',
-    backgroundColor: 'red',
-    minHeight: 'calc(90vh - 2rem)'
+    minHeight: '20rem',
+    height: 'calc(100vh - 4rem)',
+    display: 'grid',
+    gridTemplateColumns: '5fr 2fr',
+    [theme.breakpoints.down('sm')]: {
+      gridTemplateColumns: '1fr',
+    },
   },
-  text: {
-    color: theme.palette.text.primary,
-    textAlign: 'center',
-    margin: '1rem 0.5rem',
+  sidebarGridColumn: {
+    margin: '1rem',
+    backgroundColor: theme.palette.surface.default,
   },
 }));
 
@@ -21,7 +27,12 @@ const GamePage = () => {
   const classes = useStyles();
   return (
     <Box className={classes.root}>
-        <Typography className={classes.text} variant='h3'>GAME</Typography>
+      <Box className={classes.gameGridColumn}>
+        <GameBoardContainer />
+      </Box>
+      <Box className={classes.sidebarGridColumn}>
+        <GameSidebar />
+      </Box>
     </Box>
   );
 };


### PR DESCRIPTION
### Overview
This PR resolves #68 and sets up the layout of the game page. This PR also fixes the styling of the footer, and ensures it is not visible at the game page.

To access the game page, click on any position card and click "Play".

### Future TODOs
- Create chessboard component
- Link the title to the "current opening"
- Create backend endpoint to "create" a game
- Link position play to game page